### PR TITLE
feat: make getServers return the separated data

### DIFF
--- a/includes/ConfigParser.hpp
+++ b/includes/ConfigParser.hpp
@@ -27,7 +27,6 @@
 #define UPLOAD_LOC_STORE "upload_store"
 
 #define NUMBER_OF_SERVER_PRIMITIVES 7
-// #define NUMBER_OF_ONLY_ONE_PRIMITIVES 2
 #define NUMBER_OF_LOCATION_PRIMITIVES 8
 
 #define OPENNING_BRACE "{"
@@ -130,7 +129,7 @@ private:
 
 public:
 	ConfigParser(char const *inFilename);
-	std::vector<ServerData> const &getServers() const;
+	std::vector<ServerData> getServers() const;
 	std::map<int, std::vector<ServerData> > const getPortsServerDataMap() const;
 	~ConfigParser();
 	static std::string const primitives_openings[NUMBER_OF_SERVER_PRIMITIVES];

--- a/includes/ServerData.hpp
+++ b/includes/ServerData.hpp
@@ -14,6 +14,7 @@ class ServerData
 {
 private:
 	std::vector<int> _ports;
+	int _port;
 	std::string _host;
 	std::string _name;
 	int _client_body_size;
@@ -28,6 +29,9 @@ public:
 	ServerData(ServerData const &);
 	ServerData const &operator=(ServerData const &);
 	~ServerData();
+
+	void setPort(int const &);
+	int const &getPort() const;
 
 	void addPort(int const &);
 	std::vector<int> const &getPorts() const;

--- a/srcs/ConfigParser.cpp
+++ b/srcs/ConfigParser.cpp
@@ -10,11 +10,6 @@ std::string const ConfigParser::primitives_openings[NUMBER_OF_SERVER_PRIMITIVES]
 	LOCATION_OP,
 };
 
-// std::string const ConfigParser::only_one_identifiers[NUMBER_OF_NECESSARY_AND_UNIQ_PRIMITIVES] = {
-// 	HOST_OP,
-// 	ROOT_OP,
-// };
-
 std::string const ConfigParser::location_identifiers[NUMBER_OF_LOCATION_PRIMITIVES] = {
 	LOC_ROOT,
 	LOC_AUTOINDEX,
@@ -54,7 +49,6 @@ ConfigParser::ConfigParser(char const *inFilename) : _filename(inFilename)
 
 	_parseContent();
 	output << "content has been parsed successfully" << std::endl;
-	// std::cout << "content has been parsed successfully" << std::endl;
 
 	output << "======================== SERVERS PARSING ==========================" << std::endl;
 
@@ -73,9 +67,21 @@ ConfigParser::~ConfigParser()
 	_checked_location_primitives.clear();
 }
 
-std::vector<ServerData> const &ConfigParser::getServers() const
+std::vector<ServerData> ConfigParser::getServers() const
 {
-	return this->_servers;
+	std::vector<ServerData> splitedServers;
+
+	for (size_t i = 0; i < _servers.size(); i++)
+	{
+		std::vector<int> ports = _servers[i].getPorts();
+		for (size_t j = 0; j < ports.size(); j++)
+		{
+			ServerData server = _servers[i];
+			server.setPort(ports[j]);
+			splitedServers.push_back(server);
+		}
+	}
+	return splitedServers;
 }
 
 std::map<int, std::vector<ServerData> > const ConfigParser::getPortsServerDataMap() const
@@ -107,7 +113,7 @@ void ConfigParser::addServer(ServerData const &sv)
 	{
 		if (sv.getName() == _servers[i].getName())
 			throw std::runtime_error(ERROR_DUPLICATE_SERVER_NAME + sv.getName());
-		// if (sv.getHost() == _servers[i].getHost() && sv.getPorts() == _servers[i].getPorts())
+		// if (sv.getHost() == _servers[i].getHost() && sv.getPort() == _servers[i].getPort())
 		// 	throw std::runtime_error(ERROR_DUPLICATE_SERVER_HOST_AND_PORT + sv.getHost() + " - " + std::to_string(sv.getPorts()));
 	}
 	_servers.push_back(sv);

--- a/srcs/ServerData.cpp
+++ b/srcs/ServerData.cpp
@@ -20,6 +20,7 @@ ServerData const &ServerData::operator=(ServerData const &rhs)
 {
 	if (this != &rhs)
 	{
+		_port = rhs._port;
 		_ports = rhs._ports;
 		_host = rhs._host;
 		_name = rhs._name;
@@ -40,6 +41,16 @@ ServerData::~ServerData()
 	_ports.clear();
 	_error_pages.clear();
 	_locations.clear();
+}
+
+void ServerData::setPort(int const &port)
+{
+	_port = port;
+}
+
+int const &ServerData::getPort() const
+{
+	return _port;
 }
 
 void ServerData::addPort(int const &p)
@@ -155,8 +166,9 @@ bool const ServerData::hasNecessaryElements() const
 std::ostream &operator<<(std::ostream &out, const ServerData &sv)
 {
 	out << "\n==================== ServerData ===================" << std::endl;
+	out << "server port: [" << sv.getPort() << "]" << std::endl;
 	std::vector<int> ports = sv.getPorts();
-	out << "ports: ";
+	out << "all ports: ";
 	for (size_t i = 0; i < ports.size(); i++)
 	{
 		out << "[" << ports[i] << "]  ";


### PR DESCRIPTION
divide each server block which has multiple ports into subblocks which
have the same data and a specific port from the ones that have been
parsed earlier in server block
