### PR TITLE
fix(req_parse): make retval the buffer last index

### DIFF
--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -19,7 +19,7 @@ int				Connection::read()
 	{
 		bzero(buffer, 1000);
 		retval = recv(this->_socketfd, (void *)&buffer, 1000, 0);
-		buffer[1000] = '\0';
+		buffer[retval] = '\0';
 		_request.appendToData(buffer);
 		size += retval;
 		if (_request.checkDataDone())


### PR DESCRIPTION
terminate the read buffer with retval as its index of nul-terminating character